### PR TITLE
Updating the facility to allow multiple settings providers to be spec…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-language: c
- 
+language: csharp
+
+solution: AppConfigFacility.sln
 install:
-  - sudo add-apt-repository ppa:directhex/monoxide -y && sudo apt-get update
-  - sudo apt-get install mono-devel mono-gmcs nunit-console
-  - mozroots --import --sync
+  - sudo apt-get install nunit-console
   - export EnableNuGetPackageRestore=true
- 
 script:
-  - xbuild build.proj
+  - msbuild build.proj

--- a/AppConfigFacility.Azure/AppConfigFacilityExtensions.cs
+++ b/AppConfigFacility.Azure/AppConfigFacilityExtensions.cs
@@ -11,9 +11,11 @@
         /// Indicates that we should get the settings using Azure's <see cref="CloudConfigurationManager"/>.
         /// </summary>
         /// <param name="facility">The facility.</param>
-        public static void FromAzure(this AppConfigFacility facility)
+        public static AppConfigFacility FromAzure(this AppConfigFacility facility)
         {
-            facility.UseSettingsProvider<AzureSettingsProvider>();
+            facility.AddSettingsProvider<AzureSettingsProvider>();
+
+            return facility;
         }
     }
 }

--- a/AppConfigFacility/AggregateSettingsProvider.cs
+++ b/AppConfigFacility/AggregateSettingsProvider.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AppConfigFacility
+{
+    /// <summary>
+    /// A wrapper around several <see cref="ISettingsProvider"/> objects that will attempt to get
+    /// settings from each one in turn.
+    /// </summary>
+    public class AggregateSettingsProvider : ISettingsProvider
+    {
+        private readonly IReadOnlyCollection<ISettingsProvider> _settingsProviders;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="AggregateSettingsProvider"/> class.
+        /// </summary>
+        /// <param name="settingsProviders">
+        /// The list of settings providers to use to get the settings. They will be iterated over in turn,
+        /// and the first non-null result will be returned when retrieving a setting.
+        /// </param>
+        public AggregateSettingsProvider(IReadOnlyCollection<ISettingsProvider> settingsProviders)
+        {
+            if (settingsProviders == null || !settingsProviders.Any())
+            {
+                throw new ArgumentException("At least one settings provider must be specified", nameof(settingsProviders));
+            }
+
+            _settingsProviders = settingsProviders;
+        }
+
+        /// <summary>
+        /// Gets the collection of providers the aggregate provider is using.
+        /// </summary>
+        public IReadOnlyCollection<ISettingsProvider> SettingsProviders => _settingsProviders;
+
+        public object GetSetting(string key, Type returnType)
+        {
+            foreach (var provider in _settingsProviders)
+            {
+                var value = provider.GetSetting(key, returnType);
+                if (value != null)
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/AppConfigFacility/AppConfigFacility.csproj
+++ b/AppConfigFacility/AppConfigFacility.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AggregateSettingsProvider.cs" />
     <Compile Include="AppConfigFacilityExtensions.cs" />
     <Compile Include="AppConfigInterceptor.cs" />
     <Compile Include="AppSettingsProvider.cs" />

--- a/AppConfigFacility/AppConfigFacilityExtensions.cs
+++ b/AppConfigFacility/AppConfigFacilityExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace AppConfigFacility
+﻿using System.Configuration;
+
+namespace AppConfigFacility
 {
     /// <summary>
     /// Extensions for the <see cref="AppConfigFacility"/>.
@@ -9,9 +11,22 @@
         /// Indicates that we should get the settings from environment variables
         /// </summary>
         /// <param name="facility">The facility.</param>
-        public static void FromEnvironment(this AppConfigFacility facility)
+        public static AppConfigFacility FromEnvironment(this AppConfigFacility facility)
         {
-            facility.UseSettingsProvider<EnvironmentSettingsProvider>();
+            facility.AddSettingsProvider<EnvironmentSettingsProvider>();
+
+            return facility;
+        }
+
+        /// <summary>
+        /// Indicates that we should get the settings from <see cref="ConfigurationManager.AppSettings"/>.
+        /// </summary>
+        /// <param name="facility">The facility.</param>
+        public static AppConfigFacility FromAppSettings(this AppConfigFacility facility)
+        {
+            facility.AddSettingsProvider<AppSettingsProvider>();
+
+            return facility;
         }
     }
 }

--- a/AppConfigFacility/EnvironmentSettingsProvider.cs
+++ b/AppConfigFacility/EnvironmentSettingsProvider.cs
@@ -6,16 +6,11 @@ namespace AppConfigFacility
     /// Used to get settings from environment variables. If an environment variable doesn't exist
     /// or is empty for the specified key, the provider falls back to app settings.
     /// </summary>
-    public class EnvironmentSettingsProvider : AppSettingsProvider
+    public class EnvironmentSettingsProvider : SettingsProviderBase
     {
         protected override string GetSetting(string key)
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(key)))
-            {
-                return Environment.GetEnvironmentVariable(key);
-            }
-
-            return base.GetSetting(key);
+            return Environment.GetEnvironmentVariable(key);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ container.AddFacility<AppConfigFacility>(c => c.FromAzure());
 
 What this does is alters the facility so that it uses ```CloudConfigurationManager.GetSetting("MyKey")``` to access the settings.
 
+### Environment
+If you want to get your settings from the environment register the facility as follows:
+
+```csharp
+container.AddFacility<AppConfigFacility>(c => c.FromEnvironment());
+```
+
+### Multiple Sources
+You can register the facility to get the settings from multiple sources:
+
+```csharp
+container.AddFacility<AppConfigFacility>(c => c.FromEnvironment().FromAzure());
+```
+
+This will cause it to try to get each setting in the order you specify. So, in the example above, the facility will first look for a setting from an environment variable, and will then try to get it from Azure. The Azure support automatically falls back to checking AppSettings for you, but if you want to be explicit about it you can do:
+
+container.AddFacility<AppConfigFacility>(c => c.FromEnvironment().FromAzure().FromAppSettings());
+
 ### Caching
 By default the facility doesn't cache any of your settings. What this means is that it'll go back to the underlying data source (e.g. the web.config file or Azure CloudConfigurationManager) each time you get a setting. If you want it to cache your settings so it only gets them once, you can configure the facility as follows:
 

--- a/Tests/AppConfigFacility.Azure.Tests/AppConfigFacility.Azure.Tests.csproj
+++ b/Tests/AppConfigFacility.Azure.Tests/AppConfigFacility.Azure.Tests.csproj
@@ -40,6 +40,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/Tests/AppConfigFacility.Azure.Tests/AppConfigFacilityExtensionsTests.cs
+++ b/Tests/AppConfigFacility.Azure.Tests/AppConfigFacilityExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿namespace AppConfigFacility.Azure.Tests
+﻿using System.Linq;
+using Microsoft.Azure;
+
+namespace AppConfigFacility.Azure.Tests
 {
     using Castle.Windsor;
     using NUnit.Framework;
@@ -16,9 +19,9 @@
             container.AddFacility<AppConfigFacility>(c => c.FromAzure());
 
             // Assert
-            var provider = container.Resolve<ISettingsProvider>();
+            var provider = (AggregateSettingsProvider)container.Resolve<ISettingsProvider>();
 
-            Assert.IsInstanceOf<AzureSettingsProvider>(provider);
+            Assert.IsInstanceOf<AzureSettingsProvider>(provider.SettingsProviders.Single());
         }
     }
 }

--- a/Tests/AppConfigFacility.Azure.Tests/packages.config
+++ b/Tests/AppConfigFacility.Azure.Tests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Castle.Core" version="3.3.0" targetFramework="net45" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
+++ b/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
@@ -56,6 +56,8 @@
   <ItemGroup>
     <Compile Include="Integration\AppConfigFacilityPrefixTests.cs" />
     <Compile Include="Integration\AppConfigFacilityEnvironmentTests.cs" />
+    <Compile Include="Integration\AppConfigFacilityMultipleProvidersTests.cs" />
+    <Compile Include="Unit\AggregateSettingsProviderTests.cs" />
     <Compile Include="Unit\AppConfigInterceptorTests.cs" />
     <Compile Include="ISearchConfig.cs" />
     <Compile Include="ITestConfig.cs" />

--- a/Tests/AppConfigFacility.Tests/Integration/AppConfigFacilityMultipleProvidersTests.cs
+++ b/Tests/AppConfigFacility.Tests/Integration/AppConfigFacilityMultipleProvidersTests.cs
@@ -1,0 +1,81 @@
+﻿namespace AppConfigFacility.Tests.Integration
+{
+    using System;
+    using System.Configuration;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AppConfigFacilityMultipleProvidersTests
+    {
+        private WindsorContainer _container;
+
+        [Test]
+        public void CanRetrievePropertyFromEnvironment()
+        {
+            // Arrange
+            var config = CreateConfig();
+
+            const string key = "StringSetting";
+            const string value = "MyEnvironmentValue";
+
+            Environment.SetEnvironmentVariable(key, value);
+
+            // Act
+            var result = config.StringSetting;
+
+            // Assert
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public void CanFallbackToAppSettings()
+        {
+            // Arrange
+            var config = CreateConfig();
+
+            const string key = "StringSetting";
+            const string value = "MySettingValue";
+
+            Environment.SetEnvironmentVariable(key, null);
+            ConfigurationManager.AppSettings[key] = value;
+
+            // Act
+            var result = config.StringSetting;
+
+            // Assert
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public void WillAttemptToGetSettingFromEnvironmentBeforeAppSettings()
+        {
+            // Arrange
+            var config = CreateConfig();
+
+            const string key = "StringSetting";
+            const string value = "MySettingValue";
+
+            Environment.SetEnvironmentVariable(key, value);
+            ConfigurationManager.AppSettings[key] = "WrongValue";
+
+            // Act
+            var result = config.StringSetting;
+
+            // Assert
+            Assert.AreEqual(value, result);
+        }
+
+        private ITestConfig CreateConfig()
+        {
+            _container = new WindsorContainer();
+
+            _container.AddFacility<AppConfigFacility>(f => f.FromEnvironment().FromAppSettings());
+
+            _container.Register(Component.For<ITestConfig>().FromAppConfig());
+
+            return _container.Resolve<ITestConfig>();
+        }
+    }
+}

--- a/Tests/AppConfigFacility.Tests/Integration/AppConfigFacilityMultipleProvidersTests.cs
+++ b/Tests/AppConfigFacility.Tests/Integration/AppConfigFacilityMultipleProvidersTests.cs
@@ -36,10 +36,9 @@
             var config = CreateConfig();
 
             const string key = "StringSetting";
-            const string value = "MySettingValue";
+            var value = ConfigurationManager.AppSettings[key];
 
             Environment.SetEnvironmentVariable(key, null);
-            ConfigurationManager.AppSettings[key] = value;
 
             // Act
             var result = config.StringSetting;
@@ -55,10 +54,9 @@
             var config = CreateConfig();
 
             const string key = "StringSetting";
-            const string value = "MySettingValue";
+            const string value = "EnvironmentSettingValue";
 
             Environment.SetEnvironmentVariable(key, value);
-            ConfigurationManager.AppSettings[key] = "WrongValue";
 
             // Act
             var result = config.StringSetting;

--- a/Tests/AppConfigFacility.Tests/Unit/AggregateSettingsProviderTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/AggregateSettingsProviderTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using NUnit.Framework;
+
+namespace AppConfigFacility.Tests.Unit
+{
+    [TestFixture]
+    public class AggregateSettingsProviderTests
+    {
+        [Test]
+        public void GetSetting_CanGetSettingFromAppSettings()
+        {
+            // Arrange
+            const string key = "MySetting";
+            const string expectedValue = "AppSettingValue";
+
+            ConfigurationManager.AppSettings[key] = expectedValue;
+
+            var provider = new AggregateSettingsProvider(new[] {new AppSettingsProvider()});
+
+            // Act
+            var value = provider.GetSetting(key, typeof(string));
+
+            // Assert
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        [Test]
+        public void GetSetting_CanGetSettingFromEnvironmentInsteadOfAppSettings()
+        {
+            // Arrange
+            const string key = "MySetting";
+            const string expectedValue = "EnvironmentValue";
+
+            Environment.SetEnvironmentVariable(key, expectedValue);
+
+            var provider = new AggregateSettingsProvider(new List<ISettingsProvider>
+                {new EnvironmentSettingsProvider(), new AppSettingsProvider()});
+
+            // Act
+            var value = provider.GetSetting(key, typeof(string));
+
+            // Assert
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        [Test]
+        public void GetSetting_FallsBackToNextProviderIfFirstProviderHasNoValue()
+        {
+            // Arrange
+            const string key = "MySetting";
+            const string expectedValue = "AppSettingValue";
+
+            Environment.SetEnvironmentVariable(key, null);
+            ConfigurationManager.AppSettings[key] = expectedValue;
+
+            var provider = new AggregateSettingsProvider(new List<ISettingsProvider>
+                {new EnvironmentSettingsProvider(), new AppSettingsProvider()});
+
+            // Act
+            var value = provider.GetSetting(key, typeof(string));
+
+            // Assert
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        [Test]
+        public void Constructor_ThrowsExceptionIfNoProvidersAreSpecified()
+        {
+            Assert.Throws<ArgumentException>(() => new AggregateSettingsProvider(new List<ISettingsProvider>()));
+            Assert.Throws<ArgumentException>(() => new AggregateSettingsProvider(null));
+        }
+    }
+}

--- a/Tests/AppConfigFacility.Tests/Unit/AggregateSettingsProviderTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/AggregateSettingsProviderTests.cs
@@ -12,10 +12,8 @@ namespace AppConfigFacility.Tests.Unit
         public void GetSetting_CanGetSettingFromAppSettings()
         {
             // Arrange
-            const string key = "MySetting";
-            const string expectedValue = "AppSettingValue";
-
-            ConfigurationManager.AppSettings[key] = expectedValue;
+            const string key = "StringSetting";
+            var expectedValue = ConfigurationManager.AppSettings[key];
 
             var provider = new AggregateSettingsProvider(new[] {new AppSettingsProvider()});
 
@@ -30,7 +28,7 @@ namespace AppConfigFacility.Tests.Unit
         public void GetSetting_CanGetSettingFromEnvironmentInsteadOfAppSettings()
         {
             // Arrange
-            const string key = "MySetting";
+            const string key = "StringSetting";
             const string expectedValue = "EnvironmentValue";
 
             Environment.SetEnvironmentVariable(key, expectedValue);
@@ -49,11 +47,10 @@ namespace AppConfigFacility.Tests.Unit
         public void GetSetting_FallsBackToNextProviderIfFirstProviderHasNoValue()
         {
             // Arrange
-            const string key = "MySetting";
-            const string expectedValue = "AppSettingValue";
+            const string key = "StringSetting";
+            var expectedValue = ConfigurationManager.AppSettings[key];
 
             Environment.SetEnvironmentVariable(key, null);
-            ConfigurationManager.AppSettings[key] = expectedValue;
 
             var provider = new AggregateSettingsProvider(new List<ISettingsProvider>
                 {new EnvironmentSettingsProvider(), new AppSettingsProvider()});

--- a/Tests/AppConfigFacility.Tests/Unit/EnvironmentSettingsProviderTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/EnvironmentSettingsProviderTests.cs
@@ -25,13 +25,10 @@ namespace AppConfigFacility.Tests.Unit
         }
 
         [Test]
-        public void FallsBackToAppConfigIfEnvironmentVariableNotSet()
+        public void ReturnsNullIfEnvironmentVariableNotSet()
         {
             // Arrange
-            const string expectedValue = "Test123";
-            const string variableName = "AppConfigFacilityTestVar";
-
-            ConfigurationManager.AppSettings[variableName] = expectedValue;
+            const string variableName = "StringSetting";
             
             var provider = new EnvironmentSettingsProvider();
 
@@ -39,7 +36,7 @@ namespace AppConfigFacility.Tests.Unit
             var setting = (string)provider.GetSetting(variableName, typeof(string));
 
             // Assert
-            Assert.AreEqual(expectedValue, setting);
+            Assert.IsNull(setting);
         }
     }
 }


### PR DESCRIPTION
…ified

Previously I was getting the environment variable provider to fall back to app settings, but the way that was done meant that I couldn't support getting the settings from Azure settings, so you wouldn't be able to get the settings from the environment, but then fall back to Azure if no environment variable exists.