### PR TITLE
Use the ConversionManager from Castle.Windsor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ Backup*/
 UpgradeLog*.XML
 
 build/
+.vs/

--- a/AppConfigFacility.Azure/AzureSettingsProvider.cs
+++ b/AppConfigFacility.Azure/AzureSettingsProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace AppConfigFacility.Azure
+﻿using Castle.MicroKernel;
+
+namespace AppConfigFacility.Azure
 {
     using Microsoft.Azure;
 
@@ -7,6 +9,10 @@
     /// </summary>
     public class AzureSettingsProvider : SettingsProviderBase
     {
+        public AzureSettingsProvider(IKernel kernel) : base(kernel)
+        {
+        }
+
         /// <inheritdoc />
         public override string GetSetting(string key)
         {

--- a/AppConfigFacility/AggregateSettingsProvider.cs
+++ b/AppConfigFacility/AggregateSettingsProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Castle.MicroKernel;
 
 namespace AppConfigFacility
 {
@@ -15,11 +16,12 @@ namespace AppConfigFacility
         /// <summary>
         /// Creates a new instance of the <see cref="AggregateSettingsProvider"/> class.
         /// </summary>
+        /// <param name="kernel">Our current IoC Castle Windsor container</param>
         /// <param name="settingsProviders">
         /// The list of settings providers to use to get the settings. They will be iterated over in turn,
         /// and the first non-null result will be returned when retrieving a setting.
         /// </param>
-        public AggregateSettingsProvider(IReadOnlyCollection<ISettingsProvider> settingsProviders)
+        public AggregateSettingsProvider(IKernel kernel, IReadOnlyCollection<ISettingsProvider> settingsProviders) : base(kernel)
         {
             if (settingsProviders == null || !settingsProviders.Any())
             {

--- a/AppConfigFacility/AggregateSettingsProvider.cs
+++ b/AppConfigFacility/AggregateSettingsProvider.cs
@@ -36,11 +36,6 @@ namespace AppConfigFacility
         /// </summary>
         public IReadOnlyCollection<ISettingsProvider> SettingsProviders => _settingsProviders;
 
-        public override object GetSetting(string key, Type returnType)
-        {
-            return ConvertSetting(GetSetting(key), returnType);
-        }
-
         public override string GetSetting(string key)
         {
             foreach (var provider in _settingsProviders)

--- a/AppConfigFacility/AppConfigFacility.cs
+++ b/AppConfigFacility/AppConfigFacility.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Castle.MicroKernel;
 
@@ -33,14 +34,18 @@ namespace AppConfigFacility
 
         private ISettingsProvider CreateSettingsProvider(IKernel kernel)
         {
-            var providers = new List<ISettingsProvider> {new AppSettingsProvider(kernel)};
+            IReadOnlyCollection<ISettingsProvider> providers;
             if (_settingsProviderTypes.Any())
             {
                 providers = _settingsProviderTypes.Select(type =>
                 {
                     kernel.Register(Component.For(type));
                     return (ISettingsProvider) kernel.Resolve(type);
-                }).ToList();
+                }).ToList().AsReadOnly();
+            }
+            else
+            {
+                providers = new ReadOnlyCollection<ISettingsProvider>(new List<ISettingsProvider>(new []{new AppSettingsProvider(kernel)}));
             }
 
             return new AggregateSettingsProvider(kernel, providers);

--- a/AppConfigFacility/AppConfigFacility.cs
+++ b/AppConfigFacility/AppConfigFacility.cs
@@ -33,7 +33,7 @@ namespace AppConfigFacility
 
         private ISettingsProvider CreateSettingsProvider(IKernel kernel)
         {
-            var providers = new List<ISettingsProvider> {new AppSettingsProvider()};
+            var providers = new List<ISettingsProvider> {new AppSettingsProvider(kernel)};
             if (_settingsProviderTypes.Any())
             {
                 providers = _settingsProviderTypes.Select(type =>
@@ -43,7 +43,7 @@ namespace AppConfigFacility
                 }).ToList();
             }
 
-            return new AggregateSettingsProvider(providers);
+            return new AggregateSettingsProvider(kernel, providers);
         }
 
         /// <summary>

--- a/AppConfigFacility/AppSettingsProvider.cs
+++ b/AppConfigFacility/AppSettingsProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace AppConfigFacility
+﻿using Castle.MicroKernel;
+
+namespace AppConfigFacility
 {
     using System.Configuration;
 
@@ -7,6 +9,10 @@
     /// </summary>
     public class AppSettingsProvider : SettingsProviderBase
     {
+        public AppSettingsProvider(IKernel kernel) : base(kernel)
+        {
+        }
+
         /// <inheritdoc />
         public override string GetSetting(string key)
         {

--- a/AppConfigFacility/EnvironmentSettingsProvider.cs
+++ b/AppConfigFacility/EnvironmentSettingsProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Castle.MicroKernel;
 
 namespace AppConfigFacility
 {
@@ -8,6 +9,10 @@ namespace AppConfigFacility
     /// </summary>
     public class EnvironmentSettingsProvider : SettingsProviderBase
     {
+        public EnvironmentSettingsProvider(IKernel kernel) : base(kernel)
+        {
+        }
+
         /// <inheritdoc />
         public override string GetSetting(string key)
         {

--- a/AppConfigFacility/EnvironmentSettingsProvider.cs
+++ b/AppConfigFacility/EnvironmentSettingsProvider.cs
@@ -16,10 +16,7 @@ namespace AppConfigFacility
         /// <inheritdoc />
         public override string GetSetting(string key)
         {
-            return
-                Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Process)
-                ?? Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.User)
-                ?? Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Machine);
+            return Environment.GetEnvironmentVariable(key);
         }
     }
 }

--- a/AppConfigFacility/EnvironmentSettingsProvider.cs
+++ b/AppConfigFacility/EnvironmentSettingsProvider.cs
@@ -16,7 +16,10 @@ namespace AppConfigFacility
         /// <inheritdoc />
         public override string GetSetting(string key)
         {
-            return Environment.GetEnvironmentVariable(key);
+            return
+                Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Process)
+                ?? Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.User)
+                ?? Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Machine);
         }
     }
 }

--- a/AppConfigFacility/SettingsProviderBase.cs
+++ b/AppConfigFacility/SettingsProviderBase.cs
@@ -1,3 +1,6 @@
+using Castle.MicroKernel;
+using Castle.MicroKernel.SubSystems.Conversion;
+
 namespace AppConfigFacility
 {
     using System;
@@ -7,6 +10,18 @@ namespace AppConfigFacility
     /// </summary>
     public abstract class SettingsProviderBase : ISettingsProvider
     {
+        protected SettingsProviderBase(IKernel kernel)
+        {
+            if (kernel == null)
+            {
+                throw new ArgumentNullException(nameof(kernel));
+            }
+
+            ConversionManager = kernel.GetConversionManager();
+        }
+
+        protected IConversionManager ConversionManager { get; }
+
         /// <summary>
         /// Gets the specified setting and converts it to the specified type.
         /// </summary>
@@ -31,19 +46,9 @@ namespace AppConfigFacility
         /// <param name="value">The string representation.</param>
         /// <param name="returnType">The return type.</param>
         /// <returns>The value converted to the specified type.</returns>
-        protected object ConvertSetting(string value, Type returnType)
+        protected virtual object ConvertSetting(string value, Type returnType)
         {
-            if (returnType.IsEnum)
-            {
-                return Enum.Parse(returnType, value);
-            }
-
-            if (returnType == typeof(Uri))
-            {
-                return new Uri(value);
-            }
-
-            return Convert.ChangeType(value, returnType);
+            return ConversionManager.PerformConversion(value, returnType);
         }
     }
 }

--- a/Tests/AppConfigFacility.Tests/App.config
+++ b/Tests/AppConfigFacility.Tests/App.config
@@ -6,6 +6,8 @@
     <add key="EnumSetting" value="Value2" />
     <add key="BoolSetting" value="true" />
     <add key="UriSetting" value="http://localhost/SomePath" />
+    <add key="TimeSpanSetting" value="1.10:50:10"/>
+    <add key="VersionSetting" value="1.2.3.4"/>
     <add key="Search:Url" value="http://www.search.com/q=" />
   </appSettings>
 </configuration>

--- a/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
+++ b/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
@@ -58,9 +58,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Integration\AbstractTypeConverter.cs" />
     <Compile Include="Integration\AppConfigFacilityPrefixTests.cs" />
     <Compile Include="Integration\AppConfigFacilityEnvironmentTests.cs" />
     <Compile Include="Integration\AppConfigFacilityMultipleProvidersTests.cs" />
+    <Compile Include="Integration\VersionConverter.cs" />
     <Compile Include="Unit\AggregateSettingsProviderTests.cs" />
     <Compile Include="Unit\AppConfigInterceptorTests.cs" />
     <Compile Include="ISearchConfig.cs" />

--- a/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
+++ b/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestEnum.cs" />
     <Compile Include="Integration\AppConfigFacilityComputedTests.cs" />
+    <Compile Include="Unit\BaseProviderTests.cs" />
+    <Compile Include="Unit\BaseTests.cs" />
     <Compile Include="Unit\EnvironmentSettingsProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/AppConfigFacility.Tests/ITestConfig.cs
+++ b/Tests/AppConfigFacility.Tests/ITestConfig.cs
@@ -8,6 +8,8 @@
         int IntSetting { get; }
         TestEnum EnumSetting { get; }
         bool BoolSetting { get; }
+        TimeSpan TimeSpanSetting { get; }
+        Version VersionSetting { get; }
         Uri UriSetting { get; }
         string ComputedSetting { get; }
     }

--- a/Tests/AppConfigFacility.Tests/Integration/AbstractTypeConverter.cs
+++ b/Tests/AppConfigFacility.Tests/Integration/AbstractTypeConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Castle.Core.Configuration;
+using Castle.MicroKernel.SubSystems.Conversion;
+
+namespace AppConfigFacility.Tests.Integration
+{
+    /// <summary>
+    ///     Base implementation of <see cref="T:Castle.MicroKernel.SubSystems.Conversion.ITypeConverter" />
+    /// </summary>
+    [Serializable]
+    public abstract class AbstractTypeConverter : ITypeConverter
+    {
+        public ITypeConverterContext Context { get; set; }
+
+        public abstract bool CanHandleType(Type type);
+
+        public abstract object PerformConversion(string value, Type targetType);
+
+        public abstract object PerformConversion(IConfiguration configuration, Type targetType);
+
+        /// <summary>
+        ///     Returns true if this instance of <c>ITypeConverter</c>
+        ///     is able to handle the specified type with the specified
+        ///     configuration
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     The default behavior is to just pass it to the normal CanHadnleType
+        ///     peeking into the configuration is used for some advanced functionality
+        /// </remarks>
+        public virtual bool CanHandleType(Type type, IConfiguration configuration)
+        {
+            return CanHandleType(type);
+        }
+
+        public TTarget PerformConversion<TTarget>(string value)
+        {
+            return (TTarget) PerformConversion(value, typeof(TTarget));
+        }
+
+        public TTarget PerformConversion<TTarget>(IConfiguration configuration)
+        {
+            return (TTarget) PerformConversion(configuration, typeof(TTarget));
+        }
+    }
+}

--- a/Tests/AppConfigFacility.Tests/Integration/AppConfigFacilityTests.cs
+++ b/Tests/AppConfigFacility.Tests/Integration/AppConfigFacilityTests.cs
@@ -1,4 +1,7 @@
-﻿namespace AppConfigFacility.Tests.Integration
+﻿using Castle.Core.Configuration;
+using Castle.MicroKernel.SubSystems.Conversion;
+
+namespace AppConfigFacility.Tests.Integration
 {
     using System;
     using System.Configuration;
@@ -80,6 +83,34 @@
         }
 
         [Test]
+        public void CanRetrieveTimeSpanPropertyFromConfig()
+        {
+            // Arrange
+            var config = CreateConfig();
+
+            // Act
+            var result = config.TimeSpanSetting;
+
+            // Assert
+            var expected = TimeSpan.Parse(ConfigurationManager.AppSettings["TimeSpanSetting"]);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void CanRetrieveVersionPropertyFromConfig()
+        {
+            // Arrange
+            var config = CreateConfig();
+
+            // Act
+            var result = config.VersionSetting;
+
+            // Assert
+            var expected = Version.Parse(ConfigurationManager.AppSettings["VersionSetting"]);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
         public void RegistersDefaultSettingsCacheByDefault()
         {
             // Arrange
@@ -113,12 +144,13 @@
 
             _container.AddFacility<AppConfigFacility>();
 
-            _container.Register(Component.For<ITestConfig>().FromAppConfig(
-                // TODO: Something like the following for creating computed settings
-                //c => c.Configure(t => t.ComputedSetting).ComputedBy(t => t.StringSetting + " " + t.IntSetting)
-                ));
+            _container.Register(Component.For<ITestConfig>().FromAppConfig());
+
+            var conversionManager = _container.Kernel.GetConversionManager();
+            conversionManager.Add(new VersionConverter());
 
             return _container.Resolve<ITestConfig>();
         }
+        
     }
 }

--- a/Tests/AppConfigFacility.Tests/Integration/VersionConverter.cs
+++ b/Tests/AppConfigFacility.Tests/Integration/VersionConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Castle.Core.Configuration;
+
+namespace AppConfigFacility.Tests.Integration
+{
+    [Serializable]
+    public class VersionConverter : AbstractTypeConverter
+    {
+        public override bool CanHandleType(Type type)
+        {
+            return type == typeof(Version);
+        }
+
+        public override object PerformConversion(string value, Type targetType)
+        {
+            return Version.Parse(value);
+        }
+
+        public override object PerformConversion(IConfiguration configuration, Type targetType)
+        {
+            return PerformConversion(configuration.Value, targetType);
+        }
+    }
+}

--- a/Tests/AppConfigFacility.Tests/Unit/AggregateSettingsProviderTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/AggregateSettingsProviderTests.cs
@@ -5,8 +5,7 @@ using NUnit.Framework;
 
 namespace AppConfigFacility.Tests.Unit
 {
-    [TestFixture]
-    public class AggregateSettingsProviderTests
+    public class AggregateSettingsProviderTests : BaseProviderTests
     {
         [Test]
         public void GetSetting_CanGetSettingFromAppSettings()
@@ -15,7 +14,7 @@ namespace AppConfigFacility.Tests.Unit
             const string key = "StringSetting";
             var expectedValue = ConfigurationManager.AppSettings[key];
 
-            var provider = new AggregateSettingsProvider(new[] {new AppSettingsProvider()});
+            var provider = CreateAggregateSettingsProvider(new[] {typeof(AppSettingsProvider)});
 
             // Act
             var value = provider.GetSetting(key, typeof(string));
@@ -33,8 +32,12 @@ namespace AppConfigFacility.Tests.Unit
 
             Environment.SetEnvironmentVariable(key, expectedValue);
 
-            var provider = new AggregateSettingsProvider(new List<ISettingsProvider>
-                {new EnvironmentSettingsProvider(), new AppSettingsProvider()});
+            var provider = CreateAggregateSettingsProvider(
+                new[]
+                {
+                    typeof(EnvironmentSettingsProvider),
+                    typeof(AppSettingsProvider)
+                });
 
             // Act
             var value = provider.GetSetting(key, typeof(string));
@@ -52,8 +55,12 @@ namespace AppConfigFacility.Tests.Unit
 
             Environment.SetEnvironmentVariable(key, null);
 
-            var provider = new AggregateSettingsProvider(new List<ISettingsProvider>
-                {new EnvironmentSettingsProvider(), new AppSettingsProvider()});
+            var provider = CreateAggregateSettingsProvider(
+                new[]
+                {
+                    typeof(EnvironmentSettingsProvider),
+                    typeof(AppSettingsProvider)
+                });
 
             // Act
             var value = provider.GetSetting(key, typeof(string));
@@ -65,8 +72,8 @@ namespace AppConfigFacility.Tests.Unit
         [Test]
         public void Constructor_ThrowsExceptionIfNoProvidersAreSpecified()
         {
-            Assert.Throws<ArgumentException>(() => new AggregateSettingsProvider(new List<ISettingsProvider>()));
-            Assert.Throws<ArgumentException>(() => new AggregateSettingsProvider(null));
+            Assert.Throws<ArgumentException>(() => new AggregateSettingsProvider(Container.Kernel, new List<ISettingsProvider>()));
+            Assert.Throws<ArgumentException>(() => new AggregateSettingsProvider(Container.Kernel, null));
         }
     }
 }

--- a/Tests/AppConfigFacility.Tests/Unit/BaseProviderTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/BaseProviderTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Castle.MicroKernel;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using NUnit.Framework;
+
+namespace AppConfigFacility.Tests.Unit
+{
+    public abstract class BaseProviderTests : BaseTests
+    {
+        private WindsorContainer _container;
+
+        protected override void OnSetup()
+        {
+            _container = new WindsorContainer();
+            _container
+                .Register(
+                    Component.For<EnvironmentSettingsProvider>(),
+                    Component.For<AppSettingsProvider>(),
+                    Component.For<AggregateSettingsProvider>());
+        }
+
+        protected override void OnTearDown()
+        {
+            _container.Dispose();
+            _container = null;
+        }
+
+        protected IWindsorContainer Container
+        {
+            get { return _container; }
+        }
+
+        protected AggregateSettingsProvider CreateAggregateSettingsProvider(IEnumerable<Type> providerTypes)
+        {
+            IReadOnlyCollection<ISettingsProvider> settingsProviders =
+                (providerTypes ?? Enumerable.Empty<Type>())
+                .Select(providerType => (ISettingsProvider) _container.Resolve(providerType))
+                .ToList();
+
+            return _container.Resolve<AggregateSettingsProvider>(new Arguments().Insert("settingsProviders", settingsProviders));
+        }
+
+        protected AppSettingsProvider AppSettingsProvider
+        {
+            get { return _container.Resolve<AppSettingsProvider>(); }
+        }
+
+        protected EnvironmentSettingsProvider EnvironmentSettingsProvider
+        {
+            get { return _container.Resolve<EnvironmentSettingsProvider>(); }
+        }
+    }
+}

--- a/Tests/AppConfigFacility.Tests/Unit/BaseTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/BaseTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+
+namespace AppConfigFacility.Tests.Unit
+{
+    [TestFixture]
+    public abstract class BaseTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            OnSetup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            OnTearDown();
+        }
+
+        protected abstract void OnSetup();
+        protected abstract void OnTearDown();
+    }
+}

--- a/Tests/AppConfigFacility.Tests/Unit/EnvironmentSettingsProviderTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/EnvironmentSettingsProviderTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Configuration;
 using NUnit.Framework;
 
 namespace AppConfigFacility.Tests.Unit
 {
-    [TestFixture]
-    public class EnvironmentSettingsProviderTests
+    public class EnvironmentSettingsProviderTests : BaseProviderTests
     {
         [Test]
         public void CanGetSettingFromEnvironment()
@@ -15,7 +13,7 @@ namespace AppConfigFacility.Tests.Unit
             const string variableName = "AppConfigFacilityTestVar";
 
             Environment.SetEnvironmentVariable(variableName, expectedValue);
-            var provider = new EnvironmentSettingsProvider();
+            var provider = EnvironmentSettingsProvider;
 
             // Act
             var setting = (string)provider.GetSetting(variableName, typeof(string));
@@ -30,7 +28,7 @@ namespace AppConfigFacility.Tests.Unit
             // Arrange
             const string variableName = "StringSetting";
             
-            var provider = new EnvironmentSettingsProvider();
+            var provider = EnvironmentSettingsProvider;
 
             // Act
             var setting = (string)provider.GetSetting(variableName, typeof(string));


### PR DESCRIPTION
Hi,

I think that the build-in conversion manager of Castle.Windsor is better then using the current code. You can easily enhance the build-in conversion manager of Castle.Windsor. 
Out of the box more and complex types are supported. 

I also improved the EnvironmentProvider to check 3 levels:

1. Process
2. User
3. Machine

To add new types, for example the Version class:

```c#
// Register all registered ITypeConverter services to the default Conversion Manager
ITypeConverter[] typeConverters = container.ResolveAll<ITypeConverter>();
IConversionManager conversionManager = container.Kernel.GetConversionManager();
foreach (ITypeConverter converter in typeConverters)
{
    conversionManager.Add(converter);
    container.Release(converter);
}

// Base class for converters
public abstract class AbstractTypeConverter : ITypeConverter
  {
    public ITypeConverterContext Context { get; set; }

    public abstract bool CanHandleType(Type type);

    public abstract object PerformConversion(string value, Type targetType);

    public abstract object PerformConversion(IConfiguration configuration, Type targetType);

    /// <summary>
    ///   Returns true if this instance of <c>ITypeConverter</c>
    ///   is able to handle the specified type with the specified
    ///   configuration
    /// </summary>
    /// <param name="type"></param>
    /// <param name="configuration"></param>
    /// <returns></returns>
    /// <remarks>
    ///   The default behavior is to just pass it to the normal CanHadnleType
    ///   peeking into the configuration is used for some advanced functionality
    /// </remarks>
    public virtual bool CanHandleType(Type type, IConfiguration configuration)
    {
      return this.CanHandleType(type);
    }

    public TTarget PerformConversion<TTarget>(string value)
    {
      return (TTarget) this.PerformConversion(value, typeof (TTarget));
    }

    public TTarget PerformConversion<TTarget>(IConfiguration configuration)
    {
      return (TTarget) this.PerformConversion(configuration, typeof (TTarget));
    }
  }


// Version Type converter
public class VersionTypeConverter : AbstractTypeConverter
    {
        public override bool CanHandleType(Type type)
        {
            return type == typeof(Version);
        }

        public override object PerformConversion(IConfiguration configuration, Type targetType)
        {
            return PerformConversion(configuration.Value, targetType);
        }

        public override object PerformConversion(string value, Type targetType)
        {
            return Version.Parse(value);
        }
    }
```