### PR TITLE
Upgrade to Castle.Core 4.4.0 / Castle.Windsor 5.0.0

### DIFF
--- a/AppConfigFacility.Azure/AppConfigFacility.Azure.csproj
+++ b/AppConfigFacility.Azure/AppConfigFacility.Azure.csproj
@@ -35,12 +35,12 @@
     <DocumentationFile>bin\Release\AppConfigFacility.Azure.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\packages\Castle.Windsor.5.0.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/AppConfigFacility.Azure/AppConfigFacility.Azure.nuspec
+++ b/AppConfigFacility.Azure/AppConfigFacility.Azure.nuspec
@@ -12,8 +12,8 @@
 
 		<dependencies>
       <dependency id="WindsorAppConfigFacility" version="$version$" />
-		  <dependency id="Castle.Core" version="4.0.0" />
-		  <dependency id="Castle.Windsor" version="4.0.0" />
+			<dependency id="Castle.Core" version="[4.4.0, 5.0.0)" />
+			<dependency id="Castle.Windsor" version="[5.0.0, 6.0.0)" />
   		<dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
 		</dependencies>
 	</metadata>

--- a/AppConfigFacility.Azure/packages.config
+++ b/AppConfigFacility.Azure/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="Castle.Windsor" version="4.0.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
+  <package id="Castle.Windsor" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
 </packages>

--- a/AppConfigFacility/AppConfigFacility.csproj
+++ b/AppConfigFacility/AppConfigFacility.csproj
@@ -35,12 +35,12 @@
     <DocumentationFile>bin\Release\AppConfigFacility.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\packages\Castle.Windsor.5.0.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/AppConfigFacility/AppConfigFacility.nuspec
+++ b/AppConfigFacility/AppConfigFacility.nuspec
@@ -11,8 +11,8 @@
     <releaseNotes>Updated to use Windsor IConversionManager instead of Convert.ChangeType().</releaseNotes>
 
 		<dependencies>
-			<dependency id="Castle.Core" version="4.0.0" />
-  	  <dependency id="Castle.Windsor" version="4.0.0" />
+			<dependency id="Castle.Core" version="[4.4.0, 5.0.0)" />
+  	  <dependency id="Castle.Windsor" version="[5.0.0, 6.0.0)" />
 		</dependencies>
 	</metadata>
 

--- a/AppConfigFacility/packages.config
+++ b/AppConfigFacility/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="Castle.Windsor" version="4.0.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
+  <package id="Castle.Windsor" version="5.0.0" targetFramework="net45" />
 </packages>

--- a/Tests/AppConfigFacility.Azure.Tests/AppConfigFacility.Azure.Tests.csproj
+++ b/Tests/AppConfigFacility.Azure.Tests/AppConfigFacility.Azure.Tests.csproj
@@ -32,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\..\packages\Castle.Windsor.5.0.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Tests/AppConfigFacility.Azure.Tests/packages.config
+++ b/Tests/AppConfigFacility.Azure.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="Castle.Windsor" version="4.0.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
+  <package id="Castle.Windsor" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
+++ b/Tests/AppConfigFacility.Tests/AppConfigFacility.Tests.csproj
@@ -32,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
+      <HintPath>..\..\packages\Castle.Windsor.5.0.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq">

--- a/Tests/AppConfigFacility.Tests/Unit/AppConfigInterceptorTests.cs
+++ b/Tests/AppConfigFacility.Tests/Unit/AppConfigInterceptorTests.cs
@@ -1,4 +1,6 @@
-﻿namespace AppConfigFacility.Tests.Unit
+﻿using Castle.MicroKernel;
+
+namespace AppConfigFacility.Tests.Unit
 {
     using System;
     using System.Collections.Generic;
@@ -42,7 +44,7 @@
             interceptor.SetInterceptedComponentModel(
                 new ComponentModel(new ComponentName("AppConfigInterceptorTests", false),
                     new List<Type> {typeof (AppConfigInterceptorTests)}, typeof (AppConfigInterceptorTests),
-                    new Dictionary<string, object> {{AppConfigInterceptor.PrefixKey, "SomePrefix:"}}));
+                    Arguments.FromNamed(new []{ new KeyValuePair<string, object>(AppConfigInterceptor.PrefixKey, "SomePrefix:") })));
 
             _settingsProvider.Setup(p => p.GetSetting("SomePrefix:Name", typeof(string))).Returns("My Name");
             var invocation =

--- a/Tests/AppConfigFacility.Tests/packages.config
+++ b/Tests/AppConfigFacility.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="Castle.Windsor" version="4.0.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
+  <package id="Castle.Windsor" version="5.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.4.0.78" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />


### PR DESCRIPTION
New packages were NOT backward compatible, due to changes in internal classes.

For more information:
[Castle.Windsor: Issue #444](https://github.com/castleproject/Windsor/pull/444)