### PR TITLE
refactor(ci): publish test output in pipelines

### DIFF
--- a/Tests/AppConfigFacility.Tests/packages.config
+++ b/Tests/AppConfigFacility.Tests/packages.config
@@ -5,4 +5,11 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.4.0.78" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit.Console" version="3.10.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.6" targetFramework="net45" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net45" />
 </packages>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,9 @@ trigger:
 pool:
   vmImage: 'vs2017-win2016'
 
+variables:
+  buildOutputDirectory: '$(System.DefaultWorkingDirectory)\build'
+
 steps:
 - task: NuGetToolInstaller@0
   displayName: 'Install NuGet'
@@ -29,5 +32,12 @@ steps:
     solution: 'build.proj'
     msbuildArguments: '/t:NuGetPack /p:Configuration=Release;Version=$(Build.BuildNumber) /m'
 
-- publish: '$(System.DefaultWorkingDirectory)\build'
+- task: PublishTestResults@2
+  displayName: 'Publish test results'
+  inputs:
+    testResultsFormat: 'NUnit'
+    testResultsFiles: '$(buildOutputDirectory)\*-nunit.xml' 
+    mergeTestResults: true
+
+- publish: '$(buildOutputDirectory)'
   artifact: 'artifacts'

--- a/build.proj
+++ b/build.proj
@@ -4,15 +4,8 @@
   <PropertyGroup>
     <MSBuildCommunityTasksPath>$(MSBuildProjectDirectory)\.build</MSBuildCommunityTasksPath>
     <Version>1.0.0.0</Version>
-    <BuildDirectory>build</BuildDirectory>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
-    <NUnitToolPath>$(MSBuildProjectDirectory)\packages\NUnit.Runners.2.6.3\tools</NUnitToolPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
-    <NUnitToolPath>/usr/bin</NUnitToolPath>
+    <BuildDirectory>$(MSBuildProjectDirectory)\build</BuildDirectory>
+    <NUnitToolPath>$(MSBuildProjectDirectory)\packages\NUnit.ConsoleRunner.3.10.0\tools\nunit3-console.exe</NUnitToolPath>
   </PropertyGroup>
   
   <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.targets"/>
@@ -37,7 +30,7 @@
       <TestAssemblies Include="Tests\AppConfigFacility.Azure.Tests\bin\Release\*.Tests.dll" />
     </ItemGroup>
 
-    <NUnit ToolPath="$(NUnitToolPath)" Assemblies="%(TestAssemblies.Filename)%(Extension)" WorkingDirectory="%(TestAssemblies.RelativeDir)"/>
+    <Exec Command="$(NUnitToolPath) %(TestAssemblies.RelativeDir)\%(Filename)%(Extension) --result:$(BuildDirectory)\%(Filename)-nunit.xml;format=nunit3" />
   </Target>
 
   <Target Name="NuGetPack" DependsOnTargets="RunTests">


### PR DESCRIPTION

- Added a reference to NUnit.ConsoleRunner to make sure the tool is available for msbuild without it having to be installed globally.
- Added the PublishTestResults task to let pipelines know about the tests.
- Removed the cross-platform conditions for NUnit since we're not building on travis-ci anymore.